### PR TITLE
Allows for symfony/finder v3 in addition to v2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.3",
-        "symfony/finder": "~2.1"
+        "symfony/finder": "~2.1 || ~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
To allow this library to be used on both v3 and v2, this commit now
allows for v3 of symfony/finder.