### PR TITLE
Allows for symfony/finder v4 and up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.3",
-        "symfony/finder": "~2.1 || ~3.0"
+        "symfony/finder": "~2.1 || ~3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Allow this library to be used on v4 and up of `symfony/finder`.